### PR TITLE
Move QdrantClient to DI in ContextManager

### DIFF
--- a/galaxygpt-api/Program.cs
+++ b/galaxygpt-api/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.ML.Tokenizers;
 using OpenAI;
 using OpenAI.Chat;
 using OpenAI.Embeddings;
+using Qdrant.Client;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace galaxygpt_api;
@@ -70,16 +71,20 @@ public class Program
         string gptModel = configuration["GPT_MODEL"] ?? "gpt-4o-mini";
         string textEmbeddingModel = configuration["TEXT_EMBEDDING_MODEL"] ?? "text-embedding-3-small";
         string moderationModel = configuration["MODERATION_MODEL"] ?? "text-moderation-latest";
+        string[] qdrantUrlAndPort = (configuration["QDRANT_URL"] ?? "qdrant").Split(":");
 
         builder.Services.AddSingleton(openAiClient.GetChatClient(gptModel));
         builder.Services.AddSingleton(openAiClient.GetEmbeddingClient(textEmbeddingModel));
         builder.Services.AddSingleton(openAiClient.GetModerationClient(moderationModel));
         builder.Services.AddKeyedSingleton("gptTokenizer", TiktokenTokenizer.CreateForModel(gptModel));
         builder.Services.AddKeyedSingleton("embeddingsTokenizer", TiktokenTokenizer.CreateForModel(textEmbeddingModel));
+        builder.Services.AddSingleton(_ => new QdrantClient(qdrantUrlAndPort[0],
+            qdrantUrlAndPort.Length > 1 ? int.Parse(qdrantUrlAndPort[1]) : 6334));
+
         builder.Services.AddSingleton(provider => new ContextManager(
             provider.GetRequiredService<EmbeddingClient>(),
             provider.GetRequiredKeyedService<TiktokenTokenizer>("embeddingsTokenizer"),
-            configuration["QDRANT_URL"]
+            provider.GetRequiredService<QdrantClient>()
         ));
         builder.Services.AddSingleton<AiClient>();
 

--- a/galaxygpt/ContextManager.cs
+++ b/galaxygpt/ContextManager.cs
@@ -24,21 +24,22 @@ public class ContextManager
     public ContextManager(EmbeddingClient embeddingClient,
         [FromKeyedServices("embeddingsTokenizer")]
         TiktokenTokenizer embeddingsTokenizer,
-        string? qdrantUrl)
+        QdrantClient qdrantClient)
     {
         _embeddingClient = embeddingClient;
         _embeddingsTokenizer = embeddingsTokenizer;
-        string[] qdrantUrlAndPort = (qdrantUrl ?? "qdrant").Split(":");
-
-        // TODO: Move to DI (its impossible to test this class because we can't mock QdrantClient)
-        // Okay turns out this is probably going to be a bit more difficult than I thought. It doesn't seem like
-        // QDrantClient can be mocked (it doesnt expose any virtual members). We'd probably have to create a method for
-        // running the query and then mock that method instead of QdrantClient's methods.
-        _qdrantClient = new QdrantClient(qdrantUrlAndPort[0],
-            qdrantUrlAndPort.Length > 1 ? int.Parse(qdrantUrlAndPort[1]) : 6334);
+        _qdrantClient = qdrantClient;
     }
 
-    public async Task<(string, int)> FetchContext(string question, ulong maxResults = 5)
+    /// <summary>
+    /// Get the context for a question
+    /// </summary>
+    /// <param name="question">The question to get the context for</param>
+    /// <param name="maxResults">How many results to fetch. Defaults to top 5</param>
+    /// <returns>A tuple containing the context and the amount of embedding tokens the question used up</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public virtual async Task<(string context, int questiontokens)> FetchContext(string question, ulong maxResults = 5)
     {
         if (_qdrantClient == null)
             throw new InvalidOperationException("The Qdrant client is not available.");


### PR DESCRIPTION
This is cleaner and could possibly allow us to mock QdrantClient (who knows..)
Also makes `FetchContext` virtual for mocking purposes